### PR TITLE
Ability to hide user prefix in comments

### DIFF
--- a/app/src/main/java/ml/docilealligator/infinityforreddit/adapters/CommentsRecyclerViewAdapter.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/adapters/CommentsRecyclerViewAdapter.java
@@ -134,6 +134,7 @@ public class CommentsRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerVi
     private final boolean mFullyCollapseComment;
     private final boolean mShowOnlyOneCommentLevelIndicator;
     private final boolean mShowAuthorAvatar;
+    private final boolean mShowUserPrefix;
     private final boolean mHideTheNumberOfVotes;
     private final int mDepthThreshold;
     private final CommentRecyclerViewAdapterCallback mCommentRecyclerViewAdapterCallback;
@@ -287,6 +288,7 @@ public class CommentsRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerVi
         mFullyCollapseComment = sharedPreferences.getBoolean(SharedPreferencesUtils.FULLY_COLLAPSE_COMMENT, false);
         mShowOnlyOneCommentLevelIndicator = sharedPreferences.getBoolean(SharedPreferencesUtils.SHOW_ONLY_ONE_COMMENT_LEVEL_INDICATOR, false);
         mShowAuthorAvatar = sharedPreferences.getBoolean(SharedPreferencesUtils.SHOW_AUTHOR_AVATAR, false);
+        mShowUserPrefix = sharedPreferences.getBoolean(SharedPreferencesUtils.SHOW_USER_PREFIX, false);
         mHideTheNumberOfVotes = sharedPreferences.getBoolean(SharedPreferencesUtils.HIDE_THE_NUMBER_OF_VOTES_IN_COMMENTS, false);
         mDepthThreshold = sharedPreferences.getInt(SharedPreferencesUtils.SHOW_FEWER_TOOLBAR_OPTIONS_THRESHOLD, 5);
 
@@ -426,8 +428,11 @@ public class CommentsRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerVi
                     holder.itemView.setBackgroundColor(mSingleCommentThreadBackgroundColor);
                 }
 
-                String authorPrefixed = "u/" + comment.getAuthor();
-                ((CommentBaseViewHolder) holder).authorTextView.setText(authorPrefixed);
+                String authorText = comment.getAuthor();
+                if (mShowUserPrefix) { //adding prefix
+                    authorText = "u/" + authorText;
+                }
+                ((CommentBaseViewHolder) holder).authorTextView.setText(authorText);
 
                 if (comment.getAuthorFlairHTML() != null && !comment.getAuthorFlairHTML().equals("")) {
                     ((CommentBaseViewHolder) holder).authorFlairTextView.setVisibility(View.VISIBLE);
@@ -628,8 +633,12 @@ public class CommentsRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerVi
         } else if (holder instanceof CommentFullyCollapsedViewHolder) {
             Comment comment = getCurrentComment(position);
             if (comment != null) {
-                String authorWithPrefix = "u/" + comment.getAuthor();
-                ((CommentFullyCollapsedViewHolder) holder).binding.userNameTextViewItemCommentFullyCollapsed.setText(authorWithPrefix);
+
+                String authorText = comment.getAuthor();
+                if (mShowUserPrefix) { //adding prefix
+                    authorText = "u/" + authorText;
+                }
+                ((CommentFullyCollapsedViewHolder) holder).binding.userNameTextViewItemCommentFullyCollapsed.setText(authorText);
 
                 if (mShowAuthorAvatar) {
                     if (comment.getAuthorIconUrl() == null) {

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/utils/SharedPreferencesUtils.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/utils/SharedPreferencesUtils.java
@@ -208,6 +208,7 @@ public class SharedPreferencesUtils {
     public static final String HIDE_TEXT_POST_CONTENT = "hide_text_post_content";
     public static final String SHOW_FEWER_TOOLBAR_OPTIONS_THRESHOLD = "show_fewer_toolbar_options_threshold";
     public static final String SHOW_AUTHOR_AVATAR = "show_author_avatar";
+    public static final String SHOW_USER_PREFIX = "show_user_prefix";
     public static final String HIDE_UPVOTE_RATIO = "hide_upvote_ratio";
     public static final String POST_FEED_MAX_RESOLUTION = "post_feed_max_resolution";
     public static final String REDDIT_VIDEO_DEFAULT_RESOLUTION = "reddit_video_default_resolution";

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -644,6 +644,7 @@
     <string name="settings_show_fewer_toolbar_options_threshold_title">Show Fewer Toolbar Options Starting From</string>
     <string name="settings_show_fewer_toolbar_options_threshold_summary">Level %1$d</string>
     <string name="settings_show_author_avatar_title">Show Author Avatar</string>
+    <string name="settings_show_user_prefix_title">Show User Prefix</string>
     <string name="settings_hide_upvote_ratio_title">Hide Upvote Ratio</string>
     <string name="settings_miscellaneous_dangerous_group_title">Dangerous</string>
     <string name="settings_post_feed_max_resolution_warning_title">Increase the value to show previews in higher resolution, but the app may crash unexpectedly.</string>

--- a/app/src/main/res/xml/comment_preferences.xml
+++ b/app/src/main/res/xml/comment_preferences.xml
@@ -48,6 +48,11 @@
 
     <ml.docilealligator.infinityforreddit.customviews.CustomFontSwitchPreference
         app:defaultValue="false"
+        app:key="show_user_prefix"
+        android:title="@string/settings_show_user_prefix_title" />
+
+    <ml.docilealligator.infinityforreddit.customviews.CustomFontSwitchPreference
+        app:defaultValue="false"
         app:key="hide_the_number_of_votes_in_comments"
         app:title="@string/settings_hide_the_number_of_votes" />
 


### PR DESCRIPTION
Hi, this PR adds the option to hide user prefixes ("u/") in comments.
They are now hidden by default. I think this improves the compactness

Closes #50