### PR TITLE
Add subreddit name to title bar in comment view

### DIFF
--- a/app/src/main/java/ml/docilealligator/infinityforreddit/activities/ViewPostDetailActivity.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/activities/ViewPostDetailActivity.java
@@ -909,7 +909,7 @@ public class ViewPostDetailActivity extends BaseActivity implements SortTypeSele
         if (fragment != null) {
             fragment.changeSortType(sortType);
             binding.toolbarViewPostDetailActivity.setTitle("r/" + fragment.getSubredditName());
-            binding.toolbarViewPostDetailActivity.setSubtitle(sortType.getType().fullName.toLowerCase());
+            binding.toolbarViewPostDetailActivity.setSubtitle(sortType.getType().fullName);
         }
     }
 

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/fragments/ViewPostDetailFragment.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/fragments/ViewPostDetailFragment.java
@@ -1456,7 +1456,7 @@ public class ViewPostDetailFragment extends Fragment implements FragmentCommunic
                 try {
                     SortType.Type sortTypeType = SortType.Type.valueOf(mPost.getSuggestedSort().toUpperCase(Locale.US));
                     activity.setTitle(mPost.getSubredditNamePrefixed());
-                    activity.setToolbarSubtitle(sortTypeType.fullName.toLowerCase(Locale.US));
+                    activity.setToolbarSubtitle(sortTypeType.fullName);
                     ViewPostDetailFragment.this.sortType = sortTypeType;
                     fetchComments(changeRefreshState, ViewPostDetailFragment.this.sortType);
                     return;
@@ -1484,7 +1484,7 @@ public class ViewPostDetailFragment extends Fragment implements FragmentCommunic
                                 }
                             }
                             activity.setTitle(mPost.getSubredditNamePrefixed());
-                            activity.setToolbarSubtitle(sortTypeType.fullName.toLowerCase(Locale.US));
+                            activity.setToolbarSubtitle(sortTypeType.fullName);
                             ViewPostDetailFragment.this.sortType = sortTypeType;
                             fetchComments(changeRefreshState, ViewPostDetailFragment.this.sortType);
                         }
@@ -1494,7 +1494,7 @@ public class ViewPostDetailFragment extends Fragment implements FragmentCommunic
                             mRespectSubredditRecommendedSortType = false;
                             SortType.Type sortTypeType = loadSortType();
                             activity.setTitle(mPost.getSubredditNamePrefixed());
-                            activity.setToolbarSubtitle(sortTypeType.fullName.toLowerCase(Locale.US));
+                            activity.setToolbarSubtitle(sortTypeType.fullName);
                             ViewPostDetailFragment.this.sortType = sortTypeType;
                             fetchComments(changeRefreshState, ViewPostDetailFragment.this.sortType);
                         }


### PR DESCRIPTION
In addition to the sort mode, I added the subreddit name to the title bar in comment view. This is already the case with subreddit view, and this commit should make the comment view the same, improving UI consistency and also a better use of the title bar (in my opinion).