### PR TITLE
Automate releases on version bumps

### DIFF
--- a/.github/workflows/release-on-version-change.yml
+++ b/.github/workflows/release-on-version-change.yml
@@ -159,6 +159,23 @@ jobs:
         env:
           VERSION: ${{ steps.version.outputs.current }}
 
+      - name: Prepare signing config
+        if: steps.version.outputs.changed == 'true' && steps.tag_check.outputs.exists != 'true'
+        run: |
+          set -eo pipefail
+          if [ -z "${KEYSTORE_B64}" ] || [ -z "${KEYSTORE_PROPERTIES}" ]; then
+            echo "Android signing secrets are not configured. Please set ANDROID_KEYSTORE_B64 and ANDROID_KEYSTORE_PROPERTIES." >&2
+            exit 1
+          fi
+
+          echo "${KEYSTORE_B64}" | base64 --decode > release.keystore
+          mkdir -p app
+          cp release.keystore app/release.keystore
+          printf '%s' "${KEYSTORE_PROPERTIES}" > keystore.properties
+        env:
+          KEYSTORE_B64: ${{ secrets.ANDROID_KEYSTORE_B64 }}
+          KEYSTORE_PROPERTIES: ${{ secrets.ANDROID_KEYSTORE_PROPERTIES }}
+
       - name: Build and publish release
         if: steps.version.outputs.changed == 'true' && steps.tag_check.outputs.exists != 'true'
         run: |

--- a/.github/workflows/release-on-version-change.yml
+++ b/.github/workflows/release-on-version-change.yml
@@ -1,0 +1,164 @@
+name: Release on Version Change
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - app/build.gradle
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Build and Publish Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Detect version change
+        id: version
+        run: |
+          set -eo pipefail
+          current=$(awk '/^[[:space:]]*versionName[[:space:]]*"/ { gsub(/^[^"]*"/,""); gsub(/".*/,""); print; exit }' app/build.gradle)
+          if [ -z "$current" ]; then
+            echo "Unable to locate versionName in app/build.gradle" >&2
+            exit 1
+          fi
+
+          if git show HEAD^:app/build.gradle > /tmp/previous.gradle 2>/dev/null; then
+            previous=$(awk '/^[[:space:]]*versionName[[:space:]]*"/ { gsub(/^[^"]*"/,""); gsub(/".*/,""); print; exit }' /tmp/previous.gradle)
+          else
+            previous=""
+          fi
+
+          if [ "$current" != "$previous" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          echo "current=$current" >> "$GITHUB_OUTPUT"
+          echo "previous=$previous" >> "$GITHUB_OUTPUT"
+
+      - name: Stop if version unchanged
+        if: steps.version.outputs.changed != 'true'
+        run: |
+          echo "versionName unchanged (current: ${CURRENT}). Skipping release workflow."
+        env:
+          CURRENT: ${{ steps.version.outputs.current }}
+
+      - name: Set up Java
+        if: steps.version.outputs.changed == 'true'
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Set up Android SDK
+        if: steps.version.outputs.changed == 'true'
+        uses: android-actions/setup-android@v3
+        with:
+          packages: build-tools;35.0.0 platforms;android-35 platform-tools
+
+      - name: Accept Android SDK licenses
+        if: steps.version.outputs.changed == 'true'
+        run: yes | sdkmanager --licenses
+
+      - name: Set up Gradle
+        if: steps.version.outputs.changed == 'true'
+        uses: gradle/actions/setup-gradle@v3
+
+      - name: Compute release notes
+        if: steps.version.outputs.changed == 'true'
+        id: notes
+        run: |
+          set -eo pipefail
+          current_version="${CURRENT_VERSION}"
+          last_tag="$(git tag --merged HEAD --sort=-creatordate | grep -Fxv "${current_version}" | head -n 1 || true)"
+          range=""
+          if [ -n "$last_tag" ]; then
+            range="${last_tag}..HEAD"
+          fi
+
+          if [ -n "$range" ]; then
+            notes="$(git log "$range" --pretty=format:'* %s' -n 200)"
+          else
+            notes="$(git log --pretty=format:'* %s' -n 200)"
+          fi
+
+          if [ "$(printf '%s' "$notes" | wc -c)" -gt 60000 ]; then
+            notes="$(printf '%s\n' "$notes" | head -n 600)"
+            notes="${notes}"$'\n'"* (truncated release notes)"
+          fi
+
+          if [ -z "$notes" ]; then
+            notes="* Release ${current_version}"
+          fi
+
+          delimiter="EOF_$(date +%s%N)"
+          {
+            echo "notes<<${delimiter}"
+            printf '%s\n' "$notes"
+            echo "${delimiter}"
+            echo "last_tag=$last_tag"
+          } >> "$GITHUB_OUTPUT"
+        env:
+          CURRENT_VERSION: ${{ steps.version.outputs.current }}
+
+      - name: Check for existing tag
+        if: steps.version.outputs.changed == 'true'
+        id: tag_check
+        run: |
+          if git rev-parse -q --verify "refs/tags/${VERSION}" >/dev/null; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          VERSION: ${{ steps.version.outputs.current }}
+
+      - name: Stop if tag already exists
+        if: steps.version.outputs.changed == 'true' && steps.tag_check.outputs.exists == 'true'
+        run: |
+          echo "Tag ${VERSION} already exists. Nothing to release."
+        env:
+          VERSION: ${{ steps.version.outputs.current }}
+
+      - name: Prepare GitHub release properties
+        if: steps.version.outputs.changed == 'true' && steps.tag_check.outputs.exists != 'true'
+        run: |
+          cat <<EOF > github.properties
+          githubToken=${TOKEN}
+          EOF
+        env:
+          TOKEN: ${{ github.token }}
+
+      - name: Configure git for tagging
+        if: steps.version.outputs.changed == 'true' && steps.tag_check.outputs.exists != 'true'
+        run: |
+          git config user.name "${GITHUB_ACTOR}"
+          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+
+      - name: Create and push version tag
+        if: steps.version.outputs.changed == 'true' && steps.tag_check.outputs.exists != 'true'
+        run: |
+          git tag -a "${VERSION}" -m "Version ${VERSION}"
+          git push origin "${VERSION}"
+        env:
+          VERSION: ${{ steps.version.outputs.current }}
+
+      - name: Build and publish release
+        if: steps.version.outputs.changed == 'true' && steps.tag_check.outputs.exists != 'true'
+        run: |
+          cat <<'EOF' > release_notes.txt
+          ${{ steps.notes.outputs.notes }}
+          EOF
+          scripts/release-github.sh release_notes.txt
+        env:
+          GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/release-on-version-change.yml
+++ b/.github/workflows/release-on-version-change.yml
@@ -167,4 +167,5 @@ jobs:
           EOF
           scripts/release-github.sh release_notes.txt
         env:
+          GITHUB_PRERELEASE: "true"
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/release-on-version-change.yml
+++ b/.github/workflows/release-on-version-change.yml
@@ -87,18 +87,24 @@ jobs:
           fi
 
           if [ -n "$range" ]; then
-            notes="$(git log "$range" --pretty=format:'* %s' -n 200)"
+            log_notes="$(git log "$range" --pretty=format:'* %s' -n 200)"
           else
-            notes="$(git log --pretty=format:'* %s' -n 200)"
+            log_notes="$(git log --pretty=format:'* %s' -n 200)"
           fi
 
-          if [ "$(printf '%s' "$notes" | wc -c)" -gt 60000 ]; then
-            notes="$(printf '%s\n' "$notes" | head -n 600)"
-            notes="${notes}"$'\n'"* (truncated release notes)"
+          if [ "$(printf '%s' "$log_notes" | wc -c)" -gt 60000 ]; then
+            log_notes="$(printf '%s\n' "$log_notes" | head -n 600)"
+            log_notes="${log_notes}"$'\n'"* (truncated release notes)"
           fi
 
-          if [ -z "$notes" ]; then
-            notes="* Release ${current_version}"
+          if [ -z "$log_notes" ]; then
+            log_notes="* Release ${current_version}"
+          fi
+
+          notes="Note v8a is the 64-bit build, and should be considered the default choice."
+
+          if [ -n "$log_notes" ]; then
+            notes="${notes}"$'\n\n'"${log_notes}"
           fi
 
           delimiter="EOF_$(date +%s%N)"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -178,8 +178,21 @@ if (githubPropertiesFile.exists()) {
         def releaseNotes = System.getenv("RELEASE_NOTES") ?: "Automated release of version ${android.defaultConfig.versionName ?: "default-version"}"
 
         token = githubProperties["githubToken"]
-        owner = "cygnusx-1-org"
-        repo = "continuum"
+
+        def repoEnv = System.getenv("GITHUB_REPOSITORY")
+        if (repoEnv) {
+            def parts = repoEnv.split("/")
+            if (parts.length == 2) {
+                owner = parts[0]
+                repo = parts[1]
+            } else {
+                owner = githubProperties["owner"] ?: "cygnusx-1-org"
+                repo = githubProperties["repo"] ?: "continuum"
+            }
+        } else {
+            owner = githubProperties["owner"] ?: "cygnusx-1-org"
+            repo = githubProperties["repo"] ?: "continuum"
+        }
         tagName = android.defaultConfig.versionName ?: "default-version"
         targetCommitish = "master"
         releaseName = "Release ${android.defaultConfig.versionName ?: "default-version"}"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -198,7 +198,9 @@ if (githubPropertiesFile.exists()) {
         releaseName = "Release ${android.defaultConfig.versionName ?: "default-version"}"
         body = "$releaseNotes"
         draft = false
-        prerelease = false
+        def prereleaseValue = System.getenv("GITHUB_PRERELEASE")
+
+        prerelease = prereleaseValue ? prereleaseValue.toBoolean() : false
         overwrite = false
 
         // Dynamically set releaseAssets by searching the APK path

--- a/scripts/release-github.sh
+++ b/scripts/release-github.sh
@@ -1,9 +1,19 @@
 #!/bin/bash
 
-RELEASE_NOTES="${1}"
+# Allow passing release notes via a file path argument, direct string, or the RELEASE_NOTES env var.
+if [ -n "$1" ] && [ -f "$1" ]; then
+  RELEASE_NOTES="$(cat "$1")"
+elif [ -n "$1" ]; then
+  RELEASE_NOTES="$1"
+elif [ -n "$RELEASE_NOTES" ]; then
+  RELEASE_NOTES="$RELEASE_NOTES"
+else
+  RELEASE_NOTES=""
+fi
+
 export RELEASE_NOTES
 
 echo "Release notes set to: $RELEASE_NOTES"
 
-./gradlew assembleRelease
-./gradlew githubRelease
+./gradlew assembleRelease -x lintVitalRelease
+./gradlew githubRelease -x lintVitalRelease


### PR DESCRIPTION
I noticed there's been several version bumps without a release. This GitHub action automates the release process every time there's a version bump.

You can see the release created on my fork https://github.com/acrogenesis/continuum/releases/tag/8.0.6.14 (there were many tests that's why the version is "high")
This is how the GitHub action runs: https://github.com/acrogenesis/continuum/actions/runs/18453551568

Let me know if you want any changes