### PR TITLE
Adjust layout attributes for playback control buttons

### DIFF
--- a/app/src/main/res/layout/exo_playback_control_view.xml
+++ b/app/src/main/res/layout/exo_playback_control_view.xml
@@ -64,6 +64,8 @@
                 android:id="@id/exo_rew"
                 android:layout_width="48dp"
                 android:layout_height="48dp"
+                android:layout_gravity="center_vertical"
+                android:gravity="center"
                 android:background="@drawable/ic_fast_rewind_24dp"
                 android:contentDescription="@string/exo_controls_rewind_description"
                 android:scaleType="fitCenter" />
@@ -73,6 +75,7 @@
                 style="?attr/materialIconButtonOutlinedStyle"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical"
                 app:backgroundTint="@color/colorAccent"
                 app:icon="@drawable/ic_play_arrow_24dp"
                 app:iconSize="36dp"
@@ -83,6 +86,8 @@
                 android:id="@id/exo_ffwd"
                 android:layout_width="48dp"
                 android:layout_height="48dp"
+                android:layout_gravity="center_vertical"
+                android:gravity="center"
                 android:background="@drawable/ic_fast_forward_24dp"
                 android:contentDescription="@string/exo_controls_fastforward_description"
                 android:scaleType="fitCenter" />


### PR DESCRIPTION
This should fix the misalignment on the rewind and fast forward in respect to the play/pause button.
<img width="764" height="312" alt="image" src="https://github.com/user-attachments/assets/90470592-6139-4297-83a6-d2c861f7b257" />

See previous layout for comparison:
<img width="758" height="284" alt="514838811-9242a95b-4d49-4929-9d90-6cdcccb607be" src="https://github.com/user-attachments/assets/88b1356e-9c77-43e5-a8f3-339c88109030" />

Fixes #198 
