### PR TITLE
Validate OAuth response before accessing tokens

### DIFF
--- a/app/src/main/java/ml/docilealligator/infinityforreddit/activities/LoginActivity.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/activities/LoginActivity.java
@@ -185,6 +185,11 @@ public class LoginActivity extends BaseActivity {
                                         }
 
                                         JSONObject responseJSON = new JSONObject(accountResponse);
+                                        if (!responseJSON.has(APIUtils.ACCESS_TOKEN_KEY) || !responseJSON.has(APIUtils.REFRESH_TOKEN_KEY)) {
+                                            Toast.makeText(LoginActivity.this, R.string.invalid_client_id_error, Toast.LENGTH_LONG).show();
+                                            finish();
+                                            return;
+                                        }
                                         String accessToken = responseJSON.getString(APIUtils.ACCESS_TOKEN_KEY);
                                         String refreshToken = responseJSON.getString(APIUtils.REFRESH_TOKEN_KEY);
 

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/activities/LoginChromeCustomTabActivity.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/activities/LoginChromeCustomTabActivity.java
@@ -151,6 +151,11 @@ public class LoginChromeCustomTabActivity extends BaseActivity {
                                 }
 
                                 JSONObject responseJSON = new JSONObject(accountResponse);
+                                if (!responseJSON.has(APIUtils.ACCESS_TOKEN_KEY) || !responseJSON.has(APIUtils.REFRESH_TOKEN_KEY)) {
+                                    Toast.makeText(LoginChromeCustomTabActivity.this, R.string.invalid_client_id_error, Toast.LENGTH_LONG).show();
+                                    finish();
+                                    return;
+                                }
                                 String accessToken = responseJSON.getString(APIUtils.ACCESS_TOKEN_KEY);
                                 String refreshToken = responseJSON.getString(APIUtils.REFRESH_TOKEN_KEY);
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -110,6 +110,7 @@
 
     <string name="parse_json_response_error">Error occurred when parsing the JSON response</string>
     <string name="retrieve_token_error">Error Retrieving the token</string>
+    <string name="invalid_client_id_error">Invalid client ID, check your API Key setting</string>
     <string name="something_went_wrong">Something went wrong. Try again later.</string>
     <string name="access_denied">Access denied</string>
     <string name="parse_user_info_error">Error occurred when parsing the user info</string>


### PR DESCRIPTION
Fixes #246

When the OAuth response is missing the access or refresh token fields, the app was trying to access them anyway, which led to showing '{}' or other garbage. Now we check if both tokens are present in the response first, and if not, show a proper error message and close the login activity.