### PR TITLE
Feat/specific browser link handler per account

### DIFF
--- a/app/src/main/java/ml/docilealligator/infinityforreddit/activities/LinkResolverActivity.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/activities/LinkResolverActivity.java
@@ -409,9 +409,26 @@ public class LinkResolverActivity extends AppCompatActivity {
             openInCustomTabs(uri, pm, true, false);
         } else if (linkHandler == 3) {
             openInCustomTabs(uri, pm, true, true);
+        } else if (linkHandler == 4) {
+            openInSpecificBrowser(uri, pm);
         } else {
             openInWebView(uri);
         }
+    }
+
+    private void openInSpecificBrowser(Uri uri, PackageManager pm) {
+        String pkg = mSharedPreferences.getString(SharedPreferencesUtils.SPECIFIC_BROWSER_PACKAGE, "");
+        if (pkg != null && !pkg.isEmpty()) {
+            Intent intent = new Intent(Intent.ACTION_VIEW);
+            intent.setData(uri);
+            intent.setPackage(pkg);
+            try {
+                startActivity(intent);
+                return;
+            } catch (ActivityNotFoundException ignored) {
+            }
+        }
+        openInBrowser(uri, pm, true);
     }
 
     private void openInBrowser(Uri uri, PackageManager pm, boolean handleError) {

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/activities/LinkResolverActivity.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/activities/LinkResolverActivity.java
@@ -70,6 +70,9 @@ public class LinkResolverActivity extends AppCompatActivity {
     @Inject
     @Named("default")
     SharedPreferences mSharedPreferences;
+    @Inject
+    @Named("current_account")
+    SharedPreferences mCurrentAccountSharedPreferences;
 
     @Inject
     CustomThemeWrapper mCustomThemeWrapper;
@@ -402,7 +405,11 @@ public class LinkResolverActivity extends AppCompatActivity {
             return;
         }
 
-        int linkHandler = Integer.parseInt(mSharedPreferences.getString(SharedPreferencesUtils.LINK_HANDLER, "0"));
+        String accountName = mCurrentAccountSharedPreferences.getString(SharedPreferencesUtils.ACCOUNT_NAME, "");
+        String linkHandlerKey = (accountName != null && !accountName.isEmpty())
+                ? accountName + SharedPreferencesUtils.LINK_HANDLER_BASE
+                : SharedPreferencesUtils.LINK_HANDLER;
+        int linkHandler = Integer.parseInt(mSharedPreferences.getString(linkHandlerKey, "0"));
         if (linkHandler == 0) {
             openInBrowser(uri, pm, true);
         } else if (linkHandler == 1) {
@@ -417,7 +424,11 @@ public class LinkResolverActivity extends AppCompatActivity {
     }
 
     private void openInSpecificBrowser(Uri uri, PackageManager pm) {
-        String pkg = mSharedPreferences.getString(SharedPreferencesUtils.SPECIFIC_BROWSER_PACKAGE, "");
+        String accountName = mCurrentAccountSharedPreferences.getString(SharedPreferencesUtils.ACCOUNT_NAME, "");
+        String pkgKey = (accountName != null && !accountName.isEmpty())
+                ? accountName + SharedPreferencesUtils.SPECIFIC_BROWSER_PACKAGE_BASE
+                : SharedPreferencesUtils.SPECIFIC_BROWSER_PACKAGE;
+        String pkg = mSharedPreferences.getString(pkgKey, "");
         if (pkg != null && !pkg.isEmpty()) {
             Intent intent = new Intent(Intent.ACTION_VIEW);
             intent.setData(uri);
@@ -471,8 +482,11 @@ public class LinkResolverActivity extends AppCompatActivity {
     private void openInCustomTabs(Uri uri, PackageManager pm, boolean handleError, boolean ephemeral) {
         String selectedPackage = null;
         if (ephemeral) {
-            String preferredPackage = mSharedPreferences.getString(
-                    SharedPreferencesUtils.EPHEMERAL_CUSTOM_TAB_PACKAGE, "");
+            String accountName = mCurrentAccountSharedPreferences.getString(SharedPreferencesUtils.ACCOUNT_NAME, "");
+            String ephemeralPkgKey = (accountName != null && !accountName.isEmpty())
+                    ? accountName + SharedPreferencesUtils.EPHEMERAL_CUSTOM_TAB_PACKAGE_BASE
+                    : SharedPreferencesUtils.EPHEMERAL_CUSTOM_TAB_PACKAGE;
+            String preferredPackage = mSharedPreferences.getString(ephemeralPkgKey, "");
             if (preferredPackage != null && !preferredPackage.isEmpty()
                     && CustomTabsClient.isEphemeralBrowsingSupported(this, preferredPackage)) {
                 selectedPackage = preferredPackage;

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/settings/MiscellaneousPreferenceFragment.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/settings/MiscellaneousPreferenceFragment.java
@@ -51,6 +51,7 @@ public class MiscellaneousPreferenceFragment extends CustomFontPreferenceFragmen
 
         ListPreference linkHandlerListPreference = findPreference(SharedPreferencesUtils.LINK_HANDLER);
         ListPreference ephemeralBrowserListPreference = findPreference(SharedPreferencesUtils.EPHEMERAL_CUSTOM_TAB_PACKAGE);
+        EditTextPreference specificBrowserEditTextPreference = findPreference(SharedPreferencesUtils.SPECIFIC_BROWSER_PACKAGE);
         ListPreference mainPageBackButtonActionListPreference = findPreference(SharedPreferencesUtils.MAIN_PAGE_BACK_BUTTON_ACTION);
         SwitchPreference savePostFeedScrolledPositionSwitch = findPreference(SharedPreferencesUtils.SAVE_FRONT_PAGE_SCROLLED_POSITION);
         ListPreference languageListPreference = findPreference(SharedPreferencesUtils.LANGUAGE);
@@ -59,11 +60,19 @@ public class MiscellaneousPreferenceFragment extends CustomFontPreferenceFragmen
         List<String[]> ephemeralBrowsers = findEphemeralBrowsers(mActivity);
         boolean hasEphemeralBrowser = !ephemeralBrowsers.isEmpty();
 
+        if (specificBrowserEditTextPreference != null) {
+            specificBrowserEditTextPreference.setVisible(linkHandlerListPreference != null
+                    && "4".equals(linkHandlerListPreference.getValue()));
+        }
+
         if (linkHandlerListPreference != null) {
             filterLinkHandlerEntries(linkHandlerListPreference, hasEphemeralBrowser);
             linkHandlerListPreference.setOnPreferenceChangeListener((preference, newValue) -> {
                 if (ephemeralBrowserListPreference != null) {
                     ephemeralBrowserListPreference.setVisible("3".equals(newValue));
+                }
+                if (specificBrowserEditTextPreference != null) {
+                    specificBrowserEditTextPreference.setVisible("4".equals(newValue));
                 }
                 return true;
             });

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/settings/MiscellaneousPreferenceFragment.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/settings/MiscellaneousPreferenceFragment.java
@@ -36,6 +36,9 @@ import ml.docilealligator.infinityforreddit.utils.SharedPreferencesUtils;
 public class MiscellaneousPreferenceFragment extends CustomFontPreferenceFragmentCompat {
 
     @Inject
+    @Named("default")
+    SharedPreferences mSharedPreferences;
+    @Inject
     @Named("post_feed_scrolled_position_cache")
     SharedPreferences cache;
 
@@ -60,14 +63,17 @@ public class MiscellaneousPreferenceFragment extends CustomFontPreferenceFragmen
         List<String[]> ephemeralBrowsers = findEphemeralBrowsers(mActivity);
         boolean hasEphemeralBrowser = !ephemeralBrowsers.isEmpty();
 
-        if (specificBrowserEditTextPreference != null) {
-            specificBrowserEditTextPreference.setVisible(linkHandlerListPreference != null
-                    && "4".equals(linkHandlerListPreference.getValue()));
-        }
+        String linkHandlerKey = mActivity.accountName + SharedPreferencesUtils.LINK_HANDLER_BASE;
+        String ephemeralPkgKey = mActivity.accountName + SharedPreferencesUtils.EPHEMERAL_CUSTOM_TAB_PACKAGE_BASE;
+        String specificPkgKey = mActivity.accountName + SharedPreferencesUtils.SPECIFIC_BROWSER_PACKAGE_BASE;
+        String currentLinkHandler = mSharedPreferences.getString(linkHandlerKey, "0");
 
         if (linkHandlerListPreference != null) {
+            linkHandlerListPreference.setPersistent(false);
             filterLinkHandlerEntries(linkHandlerListPreference, hasEphemeralBrowser);
+            linkHandlerListPreference.setValue(currentLinkHandler);
             linkHandlerListPreference.setOnPreferenceChangeListener((preference, newValue) -> {
+                mSharedPreferences.edit().putString(linkHandlerKey, (String) newValue).apply();
                 if (ephemeralBrowserListPreference != null) {
                     ephemeralBrowserListPreference.setVisible("3".equals(newValue));
                 }
@@ -81,11 +87,29 @@ public class MiscellaneousPreferenceFragment extends CustomFontPreferenceFragmen
         if (ephemeralBrowserListPreference != null) {
             if (hasEphemeralBrowser) {
                 populateEphemeralBrowserEntries(ephemeralBrowserListPreference, ephemeralBrowsers);
-                ephemeralBrowserListPreference.setVisible(linkHandlerListPreference != null
-                        && "3".equals(linkHandlerListPreference.getValue()));
+                ephemeralBrowserListPreference.setPersistent(false);
+                String savedEphemeralPkg = mSharedPreferences.getString(ephemeralPkgKey, "");
+                if (savedEphemeralPkg != null && !savedEphemeralPkg.isEmpty()) {
+                    ephemeralBrowserListPreference.setValue(savedEphemeralPkg);
+                }
+                ephemeralBrowserListPreference.setVisible("3".equals(currentLinkHandler));
+                ephemeralBrowserListPreference.setOnPreferenceChangeListener((preference, newValue) -> {
+                    mSharedPreferences.edit().putString(ephemeralPkgKey, (String) newValue).apply();
+                    return true;
+                });
             } else {
                 ephemeralBrowserListPreference.setVisible(false);
             }
+        }
+
+        if (specificBrowserEditTextPreference != null) {
+            specificBrowserEditTextPreference.setPersistent(false);
+            specificBrowserEditTextPreference.setText(mSharedPreferences.getString(specificPkgKey, ""));
+            specificBrowserEditTextPreference.setVisible("4".equals(currentLinkHandler));
+            specificBrowserEditTextPreference.setOnPreferenceChangeListener((preference, newValue) -> {
+                mSharedPreferences.edit().putString(specificPkgKey, (String) newValue).apply();
+                return true;
+            });
         }
 
         if (mainPageBackButtonActionListPreference != null) {

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/settings/MiscellaneousPreferenceFragment.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/settings/MiscellaneousPreferenceFragment.java
@@ -6,6 +6,8 @@ import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 import android.content.pm.ServiceInfo;
+import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.widget.Toast;
 
@@ -54,7 +56,7 @@ public class MiscellaneousPreferenceFragment extends CustomFontPreferenceFragmen
 
         ListPreference linkHandlerListPreference = findPreference(SharedPreferencesUtils.LINK_HANDLER);
         ListPreference ephemeralBrowserListPreference = findPreference(SharedPreferencesUtils.EPHEMERAL_CUSTOM_TAB_PACKAGE);
-        EditTextPreference specificBrowserEditTextPreference = findPreference(SharedPreferencesUtils.SPECIFIC_BROWSER_PACKAGE);
+        ListPreference specificBrowserListPreference = findPreference(SharedPreferencesUtils.SPECIFIC_BROWSER_PACKAGE);
         ListPreference mainPageBackButtonActionListPreference = findPreference(SharedPreferencesUtils.MAIN_PAGE_BACK_BUTTON_ACTION);
         SwitchPreference savePostFeedScrolledPositionSwitch = findPreference(SharedPreferencesUtils.SAVE_FRONT_PAGE_SCROLLED_POSITION);
         ListPreference languageListPreference = findPreference(SharedPreferencesUtils.LANGUAGE);
@@ -62,6 +64,8 @@ public class MiscellaneousPreferenceFragment extends CustomFontPreferenceFragmen
 
         List<String[]> ephemeralBrowsers = findEphemeralBrowsers(mActivity);
         boolean hasEphemeralBrowser = !ephemeralBrowsers.isEmpty();
+
+        List<String[]> installedBrowsers = findInstalledBrowsers(mActivity);
 
         String linkHandlerKey = mActivity.accountName + SharedPreferencesUtils.LINK_HANDLER_BASE;
         String ephemeralPkgKey = mActivity.accountName + SharedPreferencesUtils.EPHEMERAL_CUSTOM_TAB_PACKAGE_BASE;
@@ -77,8 +81,8 @@ public class MiscellaneousPreferenceFragment extends CustomFontPreferenceFragmen
                 if (ephemeralBrowserListPreference != null) {
                     ephemeralBrowserListPreference.setVisible("3".equals(newValue));
                 }
-                if (specificBrowserEditTextPreference != null) {
-                    specificBrowserEditTextPreference.setVisible("4".equals(newValue));
+                if (specificBrowserListPreference != null) {
+                    specificBrowserListPreference.setVisible("4".equals(newValue));
                 }
                 return true;
             });
@@ -102,14 +106,22 @@ public class MiscellaneousPreferenceFragment extends CustomFontPreferenceFragmen
             }
         }
 
-        if (specificBrowserEditTextPreference != null) {
-            specificBrowserEditTextPreference.setPersistent(false);
-            specificBrowserEditTextPreference.setText(mSharedPreferences.getString(specificPkgKey, ""));
-            specificBrowserEditTextPreference.setVisible("4".equals(currentLinkHandler));
-            specificBrowserEditTextPreference.setOnPreferenceChangeListener((preference, newValue) -> {
-                mSharedPreferences.edit().putString(specificPkgKey, (String) newValue).apply();
-                return true;
-            });
+        if (specificBrowserListPreference != null) {
+            if (!installedBrowsers.isEmpty()) {
+                populateBrowserEntries(specificBrowserListPreference, installedBrowsers);
+                specificBrowserListPreference.setPersistent(false);
+                String savedPkg = mSharedPreferences.getString(specificPkgKey, "");
+                if (savedPkg != null && !savedPkg.isEmpty()) {
+                    specificBrowserListPreference.setValue(savedPkg);
+                }
+                specificBrowserListPreference.setVisible("4".equals(currentLinkHandler));
+                specificBrowserListPreference.setOnPreferenceChangeListener((preference, newValue) -> {
+                    mSharedPreferences.edit().putString(specificPkgKey, (String) newValue).apply();
+                    return true;
+                });
+            } else {
+                specificBrowserListPreference.setVisible(false);
+            }
         }
 
         if (mainPageBackButtonActionListPreference != null) {
@@ -152,6 +164,35 @@ public class MiscellaneousPreferenceFragment extends CustomFontPreferenceFragmen
                 return true;
             });
         }
+    }
+
+    private static List<String[]> findInstalledBrowsers(Context context) {
+        PackageManager pm = context.getPackageManager();
+        int flags = Build.VERSION.SDK_INT >= Build.VERSION_CODES.M
+                ? PackageManager.MATCH_ALL
+                : PackageManager.GET_DISABLED_COMPONENTS;
+        List<ResolveInfo> resolved = pm.queryIntentActivities(
+                new Intent(Intent.ACTION_VIEW, Uri.parse("http://www.example.com")), flags);
+        List<String[]> browsers = new ArrayList<>();
+        for (ResolveInfo info : resolved) {
+            if (info.activityInfo == null || !info.activityInfo.enabled) continue;
+            String pkg = info.activityInfo.applicationInfo.packageName;
+            String label = pm.getApplicationLabel(info.activityInfo.applicationInfo).toString();
+            browsers.add(new String[]{label, pkg});
+        }
+        Collections.sort(browsers, Comparator.comparing(b -> b[0].toLowerCase()));
+        return browsers;
+    }
+
+    private static void populateBrowserEntries(ListPreference pref, List<String[]> browsers) {
+        List<CharSequence> entries = new ArrayList<>();
+        List<CharSequence> values = new ArrayList<>();
+        for (String[] b : browsers) {
+            entries.add(b[0]);
+            values.add(b[1]);
+        }
+        pref.setEntries(entries.toArray(new CharSequence[0]));
+        pref.setEntryValues(values.toArray(new CharSequence[0]));
     }
 
     private static List<String[]> findEphemeralBrowsers(Context context) {

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/settings/MiscellaneousPreferenceFragment.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/settings/MiscellaneousPreferenceFragment.java
@@ -113,6 +113,10 @@ public class MiscellaneousPreferenceFragment extends CustomFontPreferenceFragmen
                 String savedPkg = mSharedPreferences.getString(specificPkgKey, "");
                 if (savedPkg != null && !savedPkg.isEmpty()) {
                     specificBrowserListPreference.setValue(savedPkg);
+                } else {
+                    String firstPkg = installedBrowsers.get(0)[1];
+                    specificBrowserListPreference.setValue(firstPkg);
+                    mSharedPreferences.edit().putString(specificPkgKey, firstPkg).apply();
                 }
                 specificBrowserListPreference.setVisible("4".equals(currentLinkHandler));
                 specificBrowserListPreference.setOnPreferenceChangeListener((preference, newValue) -> {

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/utils/SharedPreferencesUtils.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/utils/SharedPreferencesUtils.java
@@ -106,8 +106,11 @@ public class SharedPreferencesUtils {
     public static final String VOLUME_KEYS_NAVIGATE_POSTS = "volume_keys_navigate_posts";
     public static final String MUTE_VIDEO = "mute_video";
     public static final String LINK_HANDLER = "link_handler";
+    public static final String LINK_HANDLER_BASE = "_link_handler";
     public static final String EPHEMERAL_CUSTOM_TAB_PACKAGE = "ephemeral_custom_tab_package";
+    public static final String EPHEMERAL_CUSTOM_TAB_PACKAGE_BASE = "_ephemeral_custom_tab_package";
     public static final String SPECIFIC_BROWSER_PACKAGE = "specific_browser_package";
+    public static final String SPECIFIC_BROWSER_PACKAGE_BASE = "_specific_browser_package";
     public static final String VIDEO_AUTOPLAY = "video_autoplay";
     public static final String VIDEO_AUTOPLAY_VALUE_ALWAYS_ON = "2";
     public static final String VIDEO_AUTOPLAY_VALUE_ON_WIFI = "1";

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/utils/SharedPreferencesUtils.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/utils/SharedPreferencesUtils.java
@@ -107,6 +107,7 @@ public class SharedPreferencesUtils {
     public static final String MUTE_VIDEO = "mute_video";
     public static final String LINK_HANDLER = "link_handler";
     public static final String EPHEMERAL_CUSTOM_TAB_PACKAGE = "ephemeral_custom_tab_package";
+    public static final String SPECIFIC_BROWSER_PACKAGE = "specific_browser_package";
     public static final String VIDEO_AUTOPLAY = "video_autoplay";
     public static final String VIDEO_AUTOPLAY_VALUE_ALWAYS_ON = "2";
     public static final String VIDEO_AUTOPLAY_VALUE_ON_WIFI = "1";

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -1047,7 +1047,7 @@ Toque para tentar de novo."</string>
     <string name="action_go_to_wiki">"Ir à wiki"</string>
     <string name="action_playback_speed">"Velocidade de reprodução"</string>
     <string name="about">"Sobre"</string>
-    <string name="settings_link_handler_title">"Manipulador de links"</string>
+    <string name="settings_link_handler_title">"Manipulador de links (Por conta)"</string>
     <string name="settings_main_page_back_button_action">"Ação do botão de voltar na página principal"</string>
     <string name="settings_open_navigation_drawer">"Abrir gaveta de navegação"</string>
     <string name="settings_number_of_columns_in_post_feed_unfolded_portrait_title">"Retrato (desdobrado)"</string>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -676,6 +676,7 @@
         <item>@string/settings_link_handler_value_custom_tab</item>
         <item>@string/settings_link_handler_value_ephemeral_custom_tab</item>
         <item>@string/settings_link_handler_value_internal_browser</item>
+        <item>@string/settings_link_handler_value_specific_browser</item>
     </string-array>
 
     <string-array name="link_handler_values">
@@ -683,6 +684,7 @@
         <item>1</item>
         <item>3</item>
         <item>2</item>
+        <item>4</item>
     </string-array>
 
     <string-array name="settings_reddit_video_default_resolution">

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -667,7 +667,7 @@
     <string name="settings_ephemeral_custom_tab_browser_title">Ephemeral Browser</string>
     <string name="settings_link_handler_value_internal_browser">Internal Browser</string>
     <string name="settings_link_handler_value_specific_browser">Specific Browser</string>
-    <string name="settings_specific_browser_title">Specific Browser Package Name</string>
+    <string name="settings_specific_browser_title">Specific Browser</string>
     <string name="settings_legacy_autoplay_video_controller_ui_title">Legacy Video Controller UI</string>
     <string name="settings_pinch_to_zoom_video_title">Pinch to Zoom Video</string>
     <string name="settings_experimental_feature">Experimental feature</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -666,6 +666,8 @@
     <string name="settings_link_handler_value_ephemeral_custom_tab">Ephemeral Custom Tab</string>
     <string name="settings_ephemeral_custom_tab_browser_title">Ephemeral Browser</string>
     <string name="settings_link_handler_value_internal_browser">Internal Browser</string>
+    <string name="settings_link_handler_value_specific_browser">Specific Browser</string>
+    <string name="settings_specific_browser_title">Specific Browser Package Name</string>
     <string name="settings_legacy_autoplay_video_controller_ui_title">Legacy Video Controller UI</string>
     <string name="settings_pinch_to_zoom_video_title">Pinch to Zoom Video</string>
     <string name="settings_experimental_feature">Experimental feature</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -395,7 +395,7 @@
     <string name="settings_gestures_and_buttons_title">Gestures &amp; Buttons</string>
     <string name="settings_save_front_page_scrolled_position_title">Save Scrolled Position in HOME</string>
     <string name="settings_save_front_page_scrolled_position_summary">Browse new posts after refreshing in HOME (Front Page, sort type: Best)</string>
-    <string name="settings_link_handler_title">Link Handler</string>
+    <string name="settings_link_handler_title">Link Handler (Per-account)</string>
     <string name="settigns_video_title">Video</string>
     <string name="settings_video_autoplay_title">Video Autoplay</string>
     <string name="settings_simultaneous_autoplay_limit_title">Simultaneous Autoplay Limit</string>

--- a/app/src/main/res/xml/miscellaneous_preferences.xml
+++ b/app/src/main/res/xml/miscellaneous_preferences.xml
@@ -22,7 +22,7 @@
         app:title="@string/settings_ephemeral_custom_tab_browser_title"
         app:useSimpleSummaryProvider="true" />
 
-    <ml.docilealligator.infinityforreddit.customviews.preference.CustomFontEditTextPreference
+    <ml.docilealligator.infinityforreddit.customviews.preference.CustomFontListPreference
         app:defaultValue=""
         app:key="specific_browser_package"
         app:title="@string/settings_specific_browser_title"

--- a/app/src/main/res/xml/miscellaneous_preferences.xml
+++ b/app/src/main/res/xml/miscellaneous_preferences.xml
@@ -22,6 +22,12 @@
         app:title="@string/settings_ephemeral_custom_tab_browser_title"
         app:useSimpleSummaryProvider="true" />
 
+    <ml.docilealligator.infinityforreddit.customviews.preference.CustomFontEditTextPreference
+        app:defaultValue=""
+        app:key="specific_browser_package"
+        app:title="@string/settings_specific_browser_title"
+        app:useSimpleSummaryProvider="true" />
+
     <ml.docilealligator.infinityforreddit.customviews.preference.CustomFontListPreference
         app:defaultValue="0"
         app:entries="@array/main_page_back_button_action"


### PR DESCRIPTION
Users can now configure how links are opened on a per-account basis. A new "Specific Browser" option lets users manually input any browser package name, bypassing the system default. If the entered package name is invalid or the browser is not installed, it automatically falls back to the default device browser. The link handler setting is stored separately for each account, so different accounts can use different browsers.