### PR TITLE
Fix child comment count badge causing the comment to jump up when expanded

### DIFF
--- a/app/src/main/java/ml/docilealligator/infinityforreddit/adapters/CommentsRecyclerViewAdapterNew.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/adapters/CommentsRecyclerViewAdapterNew.java
@@ -995,8 +995,10 @@ public class CommentsRecyclerViewAdapterNew extends ListAdapter<Comment, Recycle
 
             // Style the child comment count badges as rounded bubbles. Each badge needs its
             // own drawable instance since a shared Drawable would share bounds between views.
+            // No vertical padding: it would make the badge taller than the sibling score text
+            // and inflate the wrap_content row, so the comment jumps up when the badge is
+            // hidden on expand.
             int badgeHorizontalPadding = (int) Utils.convertDpToPixel(4, mActivity);
-            int badgeVerticalPadding = (int) Utils.convertDpToPixel(2, mActivity);
             int badgeInset = (int) Utils.convertDpToPixel(1, mActivity);
             for (TextView childCountBadge : new TextView[]{topChildCountTextView, childCountTextView}) {
                 GradientDrawable badgeBackground = new GradientDrawable();
@@ -1004,7 +1006,7 @@ public class CommentsRecyclerViewAdapterNew extends ListAdapter<Comment, Recycle
                 badgeBackground.setCornerRadius(Utils.convertDpToPixel(8, mActivity));
                 badgeBackground.setColor(mUsernameColor);
                 childCountBadge.setBackground(new InsetDrawable(badgeBackground, badgeInset));
-                childCountBadge.setPadding(badgeHorizontalPadding, badgeVerticalPadding, badgeHorizontalPadding, badgeVerticalPadding);
+                childCountBadge.setPadding(badgeHorizontalPadding, 0, badgeHorizontalPadding, 0);
                 childCountBadge.setTextColor(mCommentBackgroundColor);
                 if (mActivity.typeface != null) {
                     childCountBadge.setTypeface(mActivity.typeface);


### PR DESCRIPTION
## Summary

When a collapsed comment shows the child-count badge (e.g. `+5`) next to the score/author row, expanding the comment caused the whole comment to visibly jump up by a few pixels as the badge disappeared.

## Root cause

The child-count badge `TextView` (`childCountTextViewItemPostComment` / `topChildCountTextViewItemPostComment`) is styled in `CommentsRecyclerViewAdapterNew` with 2dp of vertical padding (plus a 1dp inset). That makes its measured height `textHeight + ~4dp` — taller than the sibling score/author text it sits beside, which uses the same font size with no extra padding.

The badge lives in a `wrap_content` row that, depending on settings (e.g. author avatar hidden, or toolbar hidden), has no taller element pinning the row height. The badge therefore becomes the tallest view and inflates the row by ~4dp. When the comment is expanded the badge is set to `GONE`, the row shrinks back to its natural height, and because the container has `animateLayoutChanges` enabled, that shrink is visible as a small upward jump.

## Fix

Remove the badge's vertical padding so its height matches the surrounding text. Showing or hiding the badge then leaves the row height unchanged, which eliminates the jump. The horizontal padding and the rounded background are kept, so the badge still renders as a pill.

## Testing

- Built a debug APK and verified on-device: the badge still renders correctly, and the comment no longer jumps when expanding/collapsing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
