### PR TITLE
Add setting to restore comment top padding

### DIFF
--- a/app/src/main/java/ml/docilealligator/infinityforreddit/adapters/CommentsListingRecyclerViewAdapter.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/adapters/CommentsListingRecyclerViewAdapter.java
@@ -112,6 +112,8 @@ public class CommentsListingRecyclerViewAdapter extends PagedListAdapter<Comment
     private final boolean mShowElapsedTime;
     private final String mTimeFormatPattern;
     private final boolean mShowCommentDivider;
+    private final boolean mShowCommentTopPadding;
+    private final int mCommentTopPaddingPx;
     private final boolean mShowAbsoluteNumberOfVotes;
     private boolean canStartActivity = true;
     private NetworkState networkState;
@@ -134,6 +136,8 @@ public class CommentsListingRecyclerViewAdapter extends PagedListAdapter<Comment
         mAccountName = accountName;
         mShowElapsedTime = sharedPreferences.getBoolean(SharedPreferencesUtils.SHOW_ELAPSED_TIME_KEY, false);
         mShowCommentDivider = sharedPreferences.getBoolean(SharedPreferencesUtils.SHOW_COMMENT_DIVIDER, false);
+        mShowCommentTopPadding = sharedPreferences.getBoolean(SharedPreferencesUtils.SHOW_COMMENT_TOP_PADDING, false);
+        mCommentTopPaddingPx = (int) Utils.convertDpToPixel(8, activity);
         mShowAbsoluteNumberOfVotes = sharedPreferences.getBoolean(SharedPreferencesUtils.SHOW_ABSOLUTE_NUMBER_OF_VOTES, true);
         mVoteButtonsOnTheRight = sharedPreferences.getBoolean(SharedPreferencesUtils.VOTE_BUTTONS_ON_THE_RIGHT_KEY, false);
         mTimeFormatPattern = sharedPreferences.getString(SharedPreferencesUtils.TIME_FORMAT_KEY, SharedPreferencesUtils.TIME_FORMAT_DEFAULT_VALUE);
@@ -496,6 +500,14 @@ public class CommentsListingRecyclerViewAdapter extends PagedListAdapter<Comment
             this.saveButton = saveButton;
             this.replyButton = replyButton;
             this.commentDivider = commentDivider;
+
+            int commentTopMargin = mShowCommentTopPadding ? mCommentTopPaddingPx : 0;
+            ViewGroup.MarginLayoutParams linearLayoutParams = (ViewGroup.MarginLayoutParams) linearLayout.getLayoutParams();
+            linearLayoutParams.topMargin = commentTopMargin;
+            linearLayout.setLayoutParams(linearLayoutParams);
+            ViewGroup.MarginLayoutParams markdownLayoutParams = (ViewGroup.MarginLayoutParams) commentMarkdownView.getLayoutParams();
+            markdownLayoutParams.topMargin = commentTopMargin;
+            commentMarkdownView.setLayoutParams(markdownLayoutParams);
 
             replyButton.setVisibility(View.GONE);
 

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/adapters/CommentsRecyclerViewAdapterNew.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/adapters/CommentsRecyclerViewAdapterNew.java
@@ -111,6 +111,8 @@ public class CommentsRecyclerViewAdapterNew extends ListAdapter<Comment, Recycle
     private final boolean mCommentToolbarHideOnClick;
     private final boolean mSwapTapAndLong;
     private final boolean mShowCommentDivider;
+    private final boolean mShowCommentTopPadding;
+    private final int mCommentTopPaddingPx;
     private final int mDividerType;
     private final boolean mShowAbsoluteNumberOfVotes;
     private final boolean mFullyCollapseComment;
@@ -306,6 +308,8 @@ public class CommentsRecyclerViewAdapterNew extends ListAdapter<Comment, Recycle
         mCommentToolbarHideOnClick = sharedPreferences.getBoolean(SharedPreferencesUtils.COMMENT_TOOLBAR_HIDE_ON_CLICK, true);
         mSwapTapAndLong = sharedPreferences.getBoolean(SharedPreferencesUtils.SWAP_TAP_AND_LONG_COMMENTS, true);
         mShowCommentDivider = sharedPreferences.getBoolean(SharedPreferencesUtils.SHOW_COMMENT_DIVIDER, false);
+        mShowCommentTopPadding = sharedPreferences.getBoolean(SharedPreferencesUtils.SHOW_COMMENT_TOP_PADDING, false);
+        mCommentTopPaddingPx = (int) Utils.convertDpToPixel(8, activity);
         mDividerType = Integer.parseInt(sharedPreferences.getString(SharedPreferencesUtils.COMMENT_DIVIDER_TYPE, "0"));
         mShowAbsoluteNumberOfVotes = sharedPreferences.getBoolean(SharedPreferencesUtils.SHOW_ABSOLUTE_NUMBER_OF_VOTES, true);
         mFullyCollapseComment = sharedPreferences.getBoolean(SharedPreferencesUtils.FULLY_COLLAPSE_COMMENT, false);
@@ -895,6 +899,14 @@ public class CommentsRecyclerViewAdapterNew extends ListAdapter<Comment, Recycle
             this.replyButton = replyButton;
             this.commentIndentationView = commentIndentationView;
             this.commentDivider = commentDivider;
+
+            int commentTopMargin = mShowCommentTopPadding ? mCommentTopPaddingPx : 0;
+            ViewGroup.MarginLayoutParams linearLayoutParams = (ViewGroup.MarginLayoutParams) linearLayout.getLayoutParams();
+            linearLayoutParams.topMargin = commentTopMargin;
+            linearLayout.setLayoutParams(linearLayoutParams);
+            ViewGroup.MarginLayoutParams markdownLayoutParams = (ViewGroup.MarginLayoutParams) commentMarkdownView.getLayoutParams();
+            markdownLayoutParams.topMargin = commentTopMargin;
+            commentMarkdownView.setLayoutParams(markdownLayoutParams);
 
             if (mVoteButtonsOnTheRight) {
                 ConstraintSet constraintSet = new ConstraintSet();

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/adapters/CommentsRecyclerViewAdapterNew.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/adapters/CommentsRecyclerViewAdapterNew.java
@@ -901,9 +901,7 @@ public class CommentsRecyclerViewAdapterNew extends ListAdapter<Comment, Recycle
             this.commentDivider = commentDivider;
 
             int commentTopMargin = mShowCommentTopPadding ? mCommentTopPaddingPx : 0;
-            ViewGroup.MarginLayoutParams linearLayoutParams = (ViewGroup.MarginLayoutParams) linearLayout.getLayoutParams();
-            linearLayoutParams.topMargin = commentTopMargin;
-            linearLayout.setLayoutParams(linearLayoutParams);
+            applyCommentTopMargin(linearLayout);
             ViewGroup.MarginLayoutParams markdownLayoutParams = (ViewGroup.MarginLayoutParams) commentMarkdownView.getLayoutParams();
             markdownLayoutParams.topMargin = commentTopMargin;
             commentMarkdownView.setLayoutParams(markdownLayoutParams);
@@ -1457,6 +1455,12 @@ public class CommentsRecyclerViewAdapterNew extends ListAdapter<Comment, Recycle
     // verticalPaddingDp is per-caller: the normal row uses 2dp for breathing room, but the
     // fully-collapsed row passes 0 so the badge never grows taller than the 24dp avatar and
     // re-inflates the row (which would reintroduce the username jump on collapse).
+    private void applyCommentTopMargin(View view) {
+        ViewGroup.MarginLayoutParams layoutParams = (ViewGroup.MarginLayoutParams) view.getLayoutParams();
+        layoutParams.topMargin = mShowCommentTopPadding ? mCommentTopPaddingPx : 0;
+        view.setLayoutParams(layoutParams);
+    }
+
     private void styleChildCountBadge(TextView childCountBadge, int verticalPaddingDp) {
         int badgeHorizontalPadding = (int) Utils.convertDpToPixel(4, mActivity);
         int badgeVerticalPadding = (int) Utils.convertDpToPixel(verticalPaddingDp, mActivity);
@@ -1479,6 +1483,8 @@ public class CommentsRecyclerViewAdapterNew extends ListAdapter<Comment, Recycle
         public CommentFullyCollapsedViewHolder(@NonNull ItemCommentFullyCollapsedBinding binding) {
             super(binding.getRoot());
             this.binding = binding;
+
+            applyCommentTopMargin(binding.headerLinearLayoutItemCommentFullyCollapsed);
 
             if (mActivity.typeface != null) {
                 binding.userNameTextViewItemCommentFullyCollapsed.setTypeface(mActivity.typeface);

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/settings/SettingsSearchRegistry.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/settings/SettingsSearchRegistry.java
@@ -326,6 +326,9 @@ public class SettingsSearchRegistry {
                 CommentPreferenceFragment.class, R.string.settings_category_comment_title);
         add(items, c.getString(R.string.settings_show_comment_divider_title), null, bc,
                 CommentPreferenceFragment.class, R.string.settings_category_comment_title);
+        add(items, c.getString(R.string.settings_show_comment_top_padding_title),
+                c.getString(R.string.settings_show_comment_top_padding_summary), bc,
+                CommentPreferenceFragment.class, R.string.settings_category_comment_title);
         add(items, c.getString(R.string.settings_show_only_one_comment_level_indicator), null, bc,
                 CommentPreferenceFragment.class, R.string.settings_category_comment_title);
         add(items, c.getString(R.string.settings_comment_toolbar_hidden), null, bc,

--- a/app/src/main/java/ml/docilealligator/infinityforreddit/utils/SharedPreferencesUtils.java
+++ b/app/src/main/java/ml/docilealligator/infinityforreddit/utils/SharedPreferencesUtils.java
@@ -134,6 +134,7 @@ public class SharedPreferencesUtils {
     public static final String COMMENT_TOOLBAR_HIDE_ON_CLICK = "comment_toolbar_hide_on_click";
     public static final String FULLY_COLLAPSE_COMMENT = "fully_collapse_comment";
     public static final String SHOW_COMMENT_DIVIDER = "show_comment_divider";
+    public static final String SHOW_COMMENT_TOP_PADDING = "show_comment_top_padding";
     public static final String SHOW_ABSOLUTE_NUMBER_OF_VOTES = "show_absolute_number_of_votes";
     public static final String CUSTOMIZE_LIGHT_THEME = "customize_light_theme";
     public static final String CUSTOMIZE_DARK_THEME = "customize_dark_theme";

--- a/app/src/main/res/layout/item_comment_fully_collapsed.xml
+++ b/app/src/main/res/layout/item_comment_fully_collapsed.xml
@@ -14,6 +14,7 @@
         android:orientation="vertical">
 
         <LinearLayout
+            android:id="@+id/header_linear_layout_item_comment_fully_collapsed"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginStart="16dp"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -476,6 +476,8 @@
     <string name="settings_category_comment_title">Comment</string>
     <string name="settings_show_top_level_comments_first_title">Show Top-level Comments First</string>
     <string name="settings_show_comment_divider_title">Show Comment Divider</string>
+    <string name="settings_show_comment_top_padding_title">Show Comment Top Padding</string>
+    <string name="settings_show_comment_top_padding_summary">Restore spacing above the username and between the header and comment body</string>
     <string name="settings_comment_toolbar_hide_on_click">Click to Show/Hide Comment Toolbar</string>
     <string name="settings_fully_collapse_comment_title">Fully Collapse Comment</string>
     <string name="settings_comment_toolbar_hidden">Comment Toolbar Hidden by Default</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -477,7 +477,7 @@
     <string name="settings_show_top_level_comments_first_title">Show Top-level Comments First</string>
     <string name="settings_show_comment_divider_title">Show Comment Divider</string>
     <string name="settings_show_comment_top_padding_title">Show Comment Top Padding</string>
-    <string name="settings_show_comment_top_padding_summary">Restore spacing above the username and between the header and comment body</string>
+    <string name="settings_show_comment_top_padding_summary">Increase padding above the username and between the header and comment body</string>
     <string name="settings_comment_toolbar_hide_on_click">Click to Show/Hide Comment Toolbar</string>
     <string name="settings_fully_collapse_comment_title">Fully Collapse Comment</string>
     <string name="settings_comment_toolbar_hidden">Comment Toolbar Hidden by Default</string>

--- a/app/src/main/res/xml/comment_preferences.xml
+++ b/app/src/main/res/xml/comment_preferences.xml
@@ -12,6 +12,12 @@
         app:key="show_comment_divider"
         app:title="@string/settings_show_comment_divider_title" />
 
+    <ml.docilealligator.infinityforreddit.customviews.preference.CustomFontSwitchPreference
+        app:defaultValue="false"
+        app:key="show_comment_top_padding"
+        app:summary="@string/settings_show_comment_top_padding_summary"
+        app:title="@string/settings_show_comment_top_padding_title" />
+
     <ml.docilealligator.infinityforreddit.customviews.preference.CustomFontListPreference
         app:defaultValue="0"
         app:key="comment_divider_type"


### PR DESCRIPTION
## Summary

Adds an optional **Show Comment Top Padding** setting under Settings → Interface → Comment. When enabled, it restores the 8dp top margins that were removed in commit 05fd02f9 to make comments more compact.

This brings back the spacing above the username and between the comment header and body, matching the layout in Infinity for Reddit.

Closes #113

## Changes

- New `show_comment_top_padding` preference (default: off, preserving current compact layout)
- Applied in both `CommentsRecyclerViewAdapterNew` and `CommentsListingRecyclerViewAdapter`
- Added to searchable settings registry

## Test plan

- [ ] Open a post with comments and confirm comments remain compact by default
- [ ] Enable **Show Comment Top Padding** in Settings → Interface → Comment
- [ ] Re-open a post and confirm extra spacing appears above usernames and between header/body
- [ ] Verify the setting appears in settings search
- [ ] Toggle the setting off and confirm compact layout returns after reopening the post